### PR TITLE
Bumped timeout values of SPA tests

### DIFF
--- a/lock_login_spa_test.js
+++ b/lock_login_spa_test.js
@@ -2,14 +2,14 @@ Feature("SPA login with new responsive design");
 
 Scenario("Log in using Lock", I => {
   I.amOnPage("/");
-  I.waitForVisible("#qsLoginBtn", 3);
+  I.waitForVisible("#qsLoginBtn", 10);
   I.click("#qsLoginBtn");
-  I.waitForVisible('input[name="password"]', 5);
+  I.waitForVisible('input[name="password"]', 10);
   I.wait(1);
   I.fillField('input[name="username"]', "asdasd");
   I.fillField('input[name="password"]', "asdasd");
   I.click(".auth0-lock-widget-container .auth0-lock-submit");
-  I.waitForVisible("#profileDropDown", 5);
+  I.waitForVisible("#profileDropDown", 10);
   I.click("#profileDropDown");
   I.waitForVisible("#qsLogoutBtn");
   I.click("#qsLogoutBtn");

--- a/lock_login_spa_test.js
+++ b/lock_login_spa_test.js
@@ -1,18 +1,18 @@
-Feature('SPA login with new responsive design');
+Feature("SPA login with new responsive design");
 
-Scenario('Log in using Lock', (I) => {
-    I.amOnPage('/');
-    I.waitForVisible('#qsLoginBtn', 3);
-    I.click('#qsLoginBtn');
-    I.waitForVisible('input[name="password"]', 5);
-    I.wait(1);
-    I.fillField('input[name="username"]', 'asdasd');
-    I.fillField('input[name="password"]', 'asdasd');
-    I.click('.auth0-lock-widget-container .auth0-lock-submit');
-    I.waitForVisible('#profileDropDown', 5);
-    I.click('#profileDropDown');
-    I.waitForVisible('#qsLogoutBtn');
-    I.click('#qsLogoutBtn')
-    I.waitForVisible('#qsLoginBtn', 5);
-    I.amOnPage('/');
+Scenario("Log in using Lock", I => {
+  I.amOnPage("/");
+  I.waitForVisible("#qsLoginBtn", 3);
+  I.click("#qsLoginBtn");
+  I.waitForVisible('input[name="password"]', 5);
+  I.wait(1);
+  I.fillField('input[name="username"]', "asdasd");
+  I.fillField('input[name="password"]', "asdasd");
+  I.click(".auth0-lock-widget-container .auth0-lock-submit");
+  I.waitForVisible("#profileDropDown", 5);
+  I.click("#profileDropDown");
+  I.waitForVisible("#qsLogoutBtn");
+  I.click("#qsLogoutBtn");
+  I.waitForVisible("#qsLoginBtn", 10);
+  I.amOnPage("/");
 });


### PR DESCRIPTION
Bumped the timeout values for all UI waits in the SPA tests to 10 seconds. When running tests in CircleCI, sometimes the appearance of the Lock UI takes longer than expected, and the test fails. This is evident from the screenshots, where the UI is sometimes mid-animation when the test fails.

There's also some automatic Prettier formatting included in this PR.