### PR TITLE
Added a wait call of 3 seconds in SPA tests

### DIFF
--- a/lock_login_spa_test.js
+++ b/lock_login_spa_test.js
@@ -10,6 +10,7 @@ Scenario("Log in using Lock", I => {
   I.fillField('input[name="password"]', "asdasd");
   I.click(".auth0-lock-widget-container .auth0-lock-submit");
   I.waitForVisible("#profileDropDown", 20);
+  I.wait(3);
   I.click("#profileDropDown");
   I.waitForVisible("#qsLogoutBtn");
   I.click("#qsLogoutBtn");


### PR DESCRIPTION
This is to fix an issue testing the plain JavaScript samples.

For some reason, Puppeteer finds the #profileDropDown element on the
page even though it is invisible, but then fails when it tries to
click on it. Waiting for a few seconds gets around this, as by that time
the element should be truly visible on the page.